### PR TITLE
Add installation script to facillitate installation

### DIFF
--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -27,10 +27,12 @@ else
     echo "$FILE does not exist, please authenticate with .rmapi file"
 fi
 
-echo "Do you want to print a test page? (y/n)"
+echo "Do you want to print a test page?"
+read -p 'test page? (y/N): ' tp
 
-cowsay "Howdy there! Hopefully this printer works! Cheers to RMS!" |pandoc -o /tmp/test.pdf
-
-lp -d reMarkable /tmp/test.pdf
+if [ "$tp" = "y" ]; then
+    cowsay "Howdy there! Hopefully this printer works! Cheers to RMS!" |pandoc -o /tmp/test.pdf
+    lp -d reMarkable /tmp/test.pdf
+fi
 
 echo "All done ✓, happy printing! "

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -18,4 +18,19 @@ sudo chmod 700 /usr/lib/cups/backend/remarkable
 # Add/Update "Remarkable" cups printer
 sudo lpadmin -L 'Cloud Printer' -D 'my remarkable' -p "reMarkable" -E -v 'remarkable:/Print'
 
+# Copy user credentials for printer driver user home
+FILE=~/.rmapi
+if [ -f "$FILE" ]; then
+    echo "Installing credentials for cups user (root in debian)"
+    sudo cp $FILE /root/
+else
+    echo "$FILE does not exist, please authenticate with .rmapi file"
+fi
+
+echo "Do you want to print a test page? (y/n)"
+
+cowsay "Howdy there! Hopefully this printer works! Cheers to RMS!" |pandoc -o /tmp/test.pdf
+
+lp -d reMarkable /tmp/test.pdf
+
 echo "All done ✓, happy printing! "

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -18,4 +18,4 @@ sudo chmod 700 /usr/lib/cups/backend/remarkable
 # Add/Update "Remarkable" cups printer
 sudo lpadmin -L 'Cloud Printer' -D 'my remarkable' -p "reMarkable" -E -v 'remarkable:/Print'
 
-echo "All done ׋, happy printing! "
+echo "All done ✓, happy printing! "

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -47,7 +47,7 @@ if [ "$tp" = "y" ]; then
     echo "Hi there! Hopefully this printer works! Cheers to RMS!" >> /tmp/rminstall.txt
     pandoc -i /tmp/rminstall.txt -o /tmp/test.pdf
     lp -d reMarkable /tmp/test.pdf
-    #rm /tmp/test.pdf /tmp/rminstallcow
+    rm /tmp/test.pdf /tmp/rminstallcow
 fi
 
 echo "All done ✓, happy printing! "

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -1,4 +1,4 @@
-! /usr/bin/env bash
+#! /usr/bin/env bash
 
 # Set bash to stop execution on failed commands. For sanity and safety
 set -e

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -1,0 +1,21 @@
+! /usr/bin/env bash
+
+# Set bash to stop execution on failed commands. For sanity and safety
+set -e
+
+echo "Adding Unofficial remarkable printing driver"
+
+# Compile ppd driver & copy to somewhere where CUPS can find it.
+ppdc remarkable.drv; sudo cp ppd/remarkable.ppd /usr/share/cups/model/
+
+# Copy & rename CUPS backend script
+sudo cp remarkable.sh /usr/lib/cups/backend/remarkable
+
+# Secure permissions
+sudo chown root:root /usr/lib/cups/backend/remarkable
+sudo chmod 700 /usr/lib/cups/backend/remarkable
+
+# Add/Update "Remarkable" cups printer
+sudo lpadmin -L 'Cloud Printer' -D 'my remarkable' -p "reMarkable" -E -v 'remarkable:/Print'
+
+echo "All done ׋, happy printing! "

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -44,8 +44,10 @@ echo "Do you want to print a test page?"
 read -p 'test page? (y/N): ' tp
 
 if [ "$tp" = "y" ]; then
-    cowsay "Howdy there! Hopefully this printer works! Cheers to RMS!" |pandoc -o /tmp/test.pdf
+    echo "Hi there! Hopefully this printer works! Cheers to RMS!" >> /tmp/rminstall.txt
+    pandoc -i /tmp/rminstall.txt -o /tmp/test.pdf
     lp -d reMarkable /tmp/test.pdf
+    #rm /tmp/test.pdf /tmp/rminstallcow
 fi
 
 echo "All done ✓, happy printing! "

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -47,7 +47,7 @@ if [ "$tp" = "y" ]; then
     echo "Hi there! Hopefully this printer works! Cheers to RMS!" >> /tmp/rminstall.txt
     pandoc -i /tmp/rminstall.txt -o /tmp/test.pdf
     lp -d reMarkable /tmp/test.pdf
-    rm /tmp/test.pdf /tmp/rminstallcow
+    rm /tmp/test.pdf /tmp/rminstall.txt
 fi
 
 echo "All done ✓, happy printing! "

--- a/remarkable-cups/install.sh
+++ b/remarkable-cups/install.sh
@@ -8,6 +8,19 @@ echo "Adding Unofficial remarkable printing driver"
 # Compile ppd driver & copy to somewhere where CUPS can find it.
 ppdc remarkable.drv; sudo cp ppd/remarkable.ppd /usr/share/cups/model/
 
+# Find rmapi binary
+RMAPI=$(which rmapi)
+if [ -f $RMAPI ]; then
+    # Escape all '/' from rmapi path in order to use sed later
+    RMAPI=$(echo $RMAPI|sed 's/\//\\\//g')
+    # Replace original rmapi-location from rmapi.sh
+    template='s/#TEMPLATED_BY_INSTALL/rmapi='$RMAPI'/'
+    sed -i $template remarkable.sh
+fi
+
+# TODO Copy rmapi binary to print user (root)
+# TODO Get rid of root user, use some lower privileged user for printing
+
 # Copy & rename CUPS backend script
 sudo cp remarkable.sh /usr/lib/cups/backend/remarkable
 

--- a/remarkable-cups/remarkable.sh
+++ b/remarkable-cups/remarkable.sh
@@ -30,7 +30,7 @@ case ${#} in
 	fi
 	rm ${outname}
         ;;
-    
+
     6)
 	cat ${6} > ${outname}
         if [ ! -e ${DEVICE_URI#remarkable:} ]; then

--- a/remarkable-cups/remarkable.sh
+++ b/remarkable-cups/remarkable.sh
@@ -7,7 +7,12 @@ jobcopies=${4}
 joboptions=${5}
 jobfile=${6}
 
+#Default value if templating does not find tha binary
 rmapi=/home/mark/gosrc/bin/rmapi
+
+#### Installation script will template a new path for rmapi-binary
+#TEMPLATED_BY_INSTALL
+#### End of templating
 
 printtime=$(date +%Y-%b-%d-%H-%M)
 sanitized_jobtitle="$(echo ${jobtitle} | tr [[:blank:]:/%\&=+?\\\\#\'\`\´\*] _)"


### PR DESCRIPTION
Hi! 

Thanks for awesome tool for printing straight to reMarkable. I has benefited my workflow significantly!

Here is a small improvement that might help others to install this fine piece of software :>

Features still needed:
[✓] Basic installation script
[✓] Finding rmapi-bin -folder for user in order to template `rmapi`-variable for `remarkable.sh`-script

Possible additional features:
[✓] Prompt user for test-printing (test installation success + demo's the software)
[ ] Remove need for root user, or at least move the binary to root's home
Cheers!