### PR TITLE
set RMAPI_CONFIG

### DIFF
--- a/remarkable-cups/remarkable.sh
+++ b/remarkable-cups/remarkable.sh
@@ -8,6 +8,7 @@ joboptions=${5}
 jobfile=${6}
 
 rmapi=/home/mark/gosrc/bin/rmapi
+export RMAPI_CONFIG=$(eval echo ~${cupsuser}/.config/rmapi/rmapi.conf)
 
 printtime=$(date +%Y-%b-%d-%H-%M)
 sanitized_jobtitle="$(echo ${jobtitle} | tr [[:blank:]:/%\&=+?\\\\#\'\`\´\*] _ | sed 's/ü/u/g;s/ä/a/g;s/ö/o/g;s/Ü/U/g;s/Ä/A/g;s/Ö/O/g;s/{\\ß}/ss/g' | cut -f 1 -d '.' ).pdf"


### PR DESCRIPTION
include fix to set the config directory by @JCN-9000 (https://github.com/ofosos/scratch/issues/2#issuecomment-736366728)
Without this, new users most likely won't be able to print straight ahead, because CUPS usually runs as root and rmapi usually does not have configuration files for the root user.